### PR TITLE
fix: set Debug Print Filter to dword:0000000f

### DIFF
--- a/_posts/2018-08-21-hypervisor-from-scratch-part-1.md
+++ b/_posts/2018-08-21-hypervisor-from-scratch-part-1.md
@@ -225,15 +225,16 @@ The latest thing I remember is enabling Windows Debugging messages through the r
 
 Just perform the following steps:
 
-In the **Regedit**, add a key:
+Save the following content as `dbgview.reg`.
 
 ```
-HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Debug Print Filter
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Debug Print Filter]
+"DEFAULT"=dword:0000000f
 ```
 
-Under that, add a DWORD value named IHVDRIVER with a value of 0xFFFF.
-
-Reboot the machine, and it's good to go.
+Double-click on `dbgview.reg`. Reboot the machine, and it’s good to go.
 
 ## **Nested-virtualization**
 

--- a/_posts/2018-09-03-hypervisor-from-scratch-part-2.md
+++ b/_posts/2018-09-03-hypervisor-from-scratch-part-2.md
@@ -237,13 +237,16 @@ Unfortunately, for some unknown reason, I'm unable to view the result of `DbgPri
 
 As I mentioned in [part 1](https://rayanfam.com/topics/hypervisor-from-scratch-part-1/):
 
-In "regedit.exe", add a key:
+Save the following content as `dbgview.reg`.
 
 ```
-HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Debug Print Filter
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Debug Print Filter]
+"DEFAULT"=dword:0000000f
 ```
 
-Under that, add a DWORD value named IHVDRIVER with a value of 0xFFFF.
+Double-click on `dbgview.reg`. Reboot the machine, and it’s good to go.
 
 This method should solve the problem, but if the problem still persists, we have another option. For this purpose, we can use WinDbg to find a Windows Kernel global variable called `nt!Kd\_DEFAULT\_Mask`. This variable is responsible for showing the results in DbgView. It has a mask that I'm not aware of, so I just put a `0xffffffff` into it to simply make it show everything!
 


### PR DESCRIPTION
my windows  is  10.0.16299, the registry entries for DbgView aren't working. It took me about an hour to figure out the correct way to do it.

Save the following content as dgbview.reg.
Double-click on dgbview.reg.

```
Windows Registry Editor Version 5.00

[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Debug Print Filter]
"DEFAULT"=dword:0000000f
```

![image](https://github.com/user-attachments/assets/07d85f90-9422-482c-8d01-71ea4ce2575a)
